### PR TITLE
feat: three/addons を shared 依存として追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# XRift Item Template
+
+React Three Fiber で 3D アイテムを作成するための XRift アイテムテンプレートです。
+
+## セットアップ
+
+```bash
+npm install
+npm run dev
+```
+
+## ビルド
+
+```bash
+npm run build
+```
+
+## Shared 依存関係
+
+このテンプレートは [Module Federation](https://module-federation.io/) を使用しており、以下の依存関係はホストアプリケーション（xrift-frontend）と共有されます。アイテムのバンドルにはインライン化されず、shared チャンクとして分離されます。
+
+| パッケージ | バージョン |
+| --- | --- |
+| `react` | ^19.0.0 |
+| `react-dom` | ^19.0.0 |
+| `react/jsx-runtime` | - |
+| `three` | ^0.176.0 |
+| `three/addons` | ^0.176.0 |
+| `@react-three/fiber` | ^9.3.0 |
+| `@react-three/rapier` | ^2.1.0 |
+| `@react-three/drei` | ^10.7.3 |
+
+### `three/addons` について
+
+`three/addons` は shared 依存として利用可能です。`DRACOLoader` や `GLTFLoader` など Three.js のアドオンモジュールを使用する場合は、`three/addons/*` からインポートしてください。
+
+```tsx
+// OK: shared チャンクとして分離される
+import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js'
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js'
+```
+
+これにより、アドオンモジュールがアイテムチャンクにインライン化されることを防ぎます。インライン化された場合、`@xrift/code-security` によって `new Worker()` などが critical 違反として検出される問題が発生します。

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,10 @@ export default defineConfig({
           singleton: true,
           requiredVersion: '^0.176.0',
         },
+        'three/addons': {
+          singleton: true,
+          requiredVersion: '^0.176.0',
+        },
         '@react-three/fiber': {
           singleton: true,
           requiredVersion: '^9.3.0',


### PR DESCRIPTION
## Summary

- Module Federation の shared 設定に `three/addons` を追加（xrift-frontend の https://github.com/WebXR-JP/xrift-frontend/pull/942 に対応）
- README.md を作成し、shared 依存関係の一覧と `three/addons` の利用方法を記載

## 変更内容

### `vite.config.ts`
- shared 設定に `three/addons`（singleton, `^0.176.0`）を追加

### `README.md`（新規作成）
- セットアップ・ビルド手順
- shared 依存関係の一覧テーブル
- `three/addons` からのインポート方法の説明（DRACOLoader, GLTFLoader 等）

## Test plan

- [ ] `npm run build` でビルド成功を確認
- [ ] shared 設定に `three/addons` が含まれていることを確認

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)