### PR TITLE
world-template に合わせて shared 設定を統一

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,15 @@
     "": {
       "name": "@xrift/item-template",
       "version": "0.1.0",
+      "dependencies": {
+        "@xrift/world-components": "^0.36.1"
+      },
       "devDependencies": {
         "@originjs/vite-plugin-federation": "^1.4.1",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
         "@react-three/rapier": "^2.2.0",
+        "@react-three/uikit": "^1.0.64",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.183.1",
@@ -271,7 +275,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -329,7 +332,7 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.19.2.tgz",
       "integrity": "sha512-AZHL1jqUF55QJkJyU1yKeh4ImX2J93bVLIezT1+o0FZqTix6O06MOaqpKoJ4MmbDCsoZmwO+qc471/SDMDm2AA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -828,7 +831,6 @@
       "version": "0.10.17",
       "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
       "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@microsoft/api-extractor": {
@@ -943,7 +945,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
       "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "promise-worker-transferable": "^1.0.4"
@@ -967,11 +968,62 @@
         "pnpm": ">=7.0.1"
       }
     },
+    "node_modules/@pmndrs/msdfonts": {
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@pmndrs/msdfonts/-/msdfonts-1.0.64.tgz",
+      "integrity": "sha512-fyDNvCIGUTUYxDOzQnLOAGEuDQbyjx1JUlEYrjHB8KLDWzVl0j2SoFiLN4AwahEh4pXiA7XdJBNneQKnfMa/Bw==",
+      "devOptional": true,
+      "license": "SEE LICENSE IN LICENSE"
+    },
+    "node_modules/@pmndrs/pointer-events": {
+      "version": "6.6.29",
+      "resolved": "https://registry.npmjs.org/@pmndrs/pointer-events/-/pointer-events-6.6.29.tgz",
+      "integrity": "sha512-o4YD6VfJgDYjFgde/YyAw2X5KY454tdmOXrHGOvKTWJBHzkL90B5vH4rqmexwRVvaDfT3YLvVh/Dm5cBbgZXMg==",
+      "devOptional": true,
+      "license": "SEE LICENSE IN LICENSE"
+    },
+    "node_modules/@pmndrs/uikit": {
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@pmndrs/uikit/-/uikit-1.0.64.tgz",
+      "integrity": "sha512-FQgF8sf46U6fmHnqOn32S04lnWiXVxQO6MatL7FgoLKJ74YIBgEHgwKHRwltgLrN/rcTu7LgJm7LgvXvMccEGA==",
+      "devOptional": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@pmndrs/msdfonts": "^1.0.64",
+        "@pmndrs/uikit-pub-sub": "^1.0.64",
+        "@preact/signals-core": "^1.5.1",
+        "@zappar/msdf-generator": "^1.2.4",
+        "yoga-layout": "^3.2.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.162"
+      }
+    },
+    "node_modules/@pmndrs/uikit-pub-sub": {
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@pmndrs/uikit-pub-sub/-/uikit-pub-sub-1.0.64.tgz",
+      "integrity": "sha512-+hlc5aWC3wQlA/zihwh+OGSm3aY9O+L/TEuNLwXw6R8syHMv7obqeY6s/hcjzD92k6DRQZLhVzVy+yqqVKAbRA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.8.0"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.1.tgz",
+      "integrity": "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/@react-three/drei": {
       "version": "10.7.7",
       "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
       "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
@@ -1012,7 +1064,6 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.5.0.tgz",
       "integrity": "sha512-FiUzfYW4wB1+PpmsE47UM+mCads7j2+giRBltfwH7SNhah95rqJs3ltEs9V3pP8rYdS0QlNne+9Aj8dS/SiaIA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.8",
@@ -1061,7 +1112,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@react-three/rapier/-/rapier-2.2.0.tgz",
       "integrity": "sha512-mVsqbKXlGZoN+XrqdhzFZUQmy8pibEOVzl4k7LC+LHe84bQnYBSagy1Hvbda6bL1PJDdTFyiDiBk5buKFinNIQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "0.19.2",
         "suspend-react": "^0.1.3",
@@ -1071,6 +1122,24 @@
         "@react-three/fiber": "^9.0.4",
         "react": "^19",
         "three": ">=0.159.0"
+      }
+    },
+    "node_modules/@react-three/uikit": {
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@react-three/uikit/-/uikit-1.0.64.tgz",
+      "integrity": "sha512-//wUWePJHHHWgDokWs2WUs8yUqOJ1Dy/g1OufGHw/BeTujtoNG0hmuISjdeDXZOQPfNjpMgrbemfmvryTeCfLg==",
+      "devOptional": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@pmndrs/pointer-events": "^6.6.29",
+        "@pmndrs/uikit": "^1.0.64",
+        "@preact/signals-core": "^1.5.1",
+        "suspend-react": "^0.1.3",
+        "zustand": "^5.0.6"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=8",
+        "react": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1584,7 +1653,6 @@
       "version": "23.1.3",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
       "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/argparse": {
@@ -1643,7 +1711,6 @@
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
       "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -1657,14 +1724,12 @@
       "version": "2019.7.3",
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1684,7 +1749,6 @@
       "version": "0.28.9",
       "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
       "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
@@ -1694,14 +1758,12 @@
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
       "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/three": {
       "version": "0.183.1",
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.1.tgz",
       "integrity": "sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
@@ -1717,28 +1779,24 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@types/webxr": {
       "version": "0.5.24",
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@use-gesture/core": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
       "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@use-gesture/react": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
       "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@use-gesture/core": "10.3.1"
@@ -1909,8 +1967,46 @@
       "version": "0.1.69",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
       "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
-      "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@xrift/world-components": {
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.36.1.tgz",
+      "integrity": "sha512-mSXA3Ibe0eZcPMbl8JZ7VB18syYf6AqnYn25N+nylqoPFuddPp/ZIO/bxm8TOltBSWmCC2exmUNMWgY40vpm8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@react-three/drei": "^10.0.0",
+        "@react-three/fiber": "^9.0.0",
+        "@react-three/rapier": "^2.0.0",
+        "@react-three/uikit": "^1.0.0",
+        "hls.js": "^1.5.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "three": ">=0.176.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-three/rapier": {
+          "optional": true
+        },
+        "@react-three/uikit": {
+          "optional": true
+        },
+        "hls.js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@zappar/msdf-generator": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@zappar/msdf-generator/-/msdf-generator-1.2.4.tgz",
+      "integrity": "sha512-6S/MCk0Ky0ipewZJw4xFEzH/2aYfWmPXEkTdBtNyDDfkbicrNwgJgtxZ4SnTDyNe9XHMqDA4sL9srRsgDLRMqA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "comlink": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -2006,7 +2102,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2040,7 +2135,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -2097,7 +2191,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2122,7 +2215,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
       "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0",
@@ -2153,6 +2245,13 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/compare-versions": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
@@ -2178,7 +2277,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
       "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.1"
@@ -2197,7 +2295,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2212,7 +2309,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/de-indent": {
@@ -2244,7 +2340,6 @@
       "version": "5.0.70",
       "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
       "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "webgl-constants": "^1.1.1"
@@ -2264,7 +2359,6 @@
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
       "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/electron-to-chromium": {
@@ -2402,7 +2496,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fs-extra": {
@@ -2459,7 +2552,6 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
       "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/graceful-fs": {
@@ -2506,14 +2598,12 @@
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.15.tgz",
       "integrity": "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2534,7 +2624,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-lazy": {
@@ -2567,21 +2656,18 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/its-fine": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
       "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/react-reconciler": "^0.28.9"
@@ -2661,7 +2747,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
@@ -2706,7 +2791,6 @@
       "version": "0.10.8",
       "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
       "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/three": ">=0.134.0",
@@ -2730,7 +2814,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
       "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "three": ">=0.137"
@@ -2740,7 +2823,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.0.1.tgz",
       "integrity": "sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/minimatch": {
@@ -2842,7 +2924,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2927,14 +3008,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
       "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
       "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "is-promise": "^2.1.0",
@@ -2962,7 +3041,6 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2972,7 +3050,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -2995,7 +3073,6 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
       "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.13",
@@ -3011,7 +3088,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3087,7 +3163,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -3104,7 +3179,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3117,7 +3191,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3154,7 +3227,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
       "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/three": "*",
@@ -3169,14 +3241,12 @@
       "version": "0.170.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
       "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/stats.js": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
       "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-argv": {
@@ -3235,7 +3305,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
       "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": ">=17.0"
@@ -3245,14 +3314,12 @@
       "version": "0.183.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
       "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
       "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "three": ">= 0.159.0"
@@ -3262,7 +3329,6 @@
       "version": "2.36.1",
       "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
       "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/draco3d": "^1.4.0",
@@ -3280,7 +3346,6 @@
       "version": "0.6.10",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
       "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -3304,7 +3369,6 @@
       "version": "0.52.4",
       "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
       "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.2",
@@ -3320,7 +3384,6 @@
       "version": "0.52.4",
       "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
       "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "three": ">=0.125.0"
@@ -3330,14 +3393,12 @@
       "version": "0.52.0",
       "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
       "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tunnel-rat": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
       "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "zustand": "^4.3.2"
@@ -3347,7 +3408,6 @@
       "version": "4.5.7",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
       "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "use-sync-external-store": "^1.2.2"
@@ -3438,7 +3498,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -3448,7 +3507,6 @@
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
       "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -3576,21 +3634,18 @@
     "node_modules/webgl-constants": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
-      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==",
-      "dev": true
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
     },
     "node_modules/webgl-sdf-generator": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
       "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3609,11 +3664,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/zustand": {
       "version": "5.0.11",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
       "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
     "@react-three/rapier": "^2.2.0",
+    "@react-three/uikit": "^1.0.64",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.183.1",
@@ -48,5 +49,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@xrift/world-components": "^0.36.1"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,9 +35,8 @@ export default defineConfig({
           singleton: true,
           requiredVersion: '^0.176.0',
         },
-        'three/addons': {
+        'three/addons/loaders/DRACOLoader.js': {
           singleton: true,
-          requiredVersion: '^0.176.0',
         },
         '@react-three/fiber': {
           singleton: true,
@@ -50,6 +49,14 @@ export default defineConfig({
         '@react-three/drei': {
           singleton: true,
           requiredVersion: '^10.7.3',
+        },
+        '@react-three/uikit': {
+          singleton: true,
+          requiredVersion: '^1.0.0',
+        },
+        '@xrift/world-components': {
+          singleton: true,
+          requiredVersion: '^0.1.0',
         },
       },
     }),


### PR DESCRIPTION
## Summary
- federation の `shared` 構成を [xrift-world-template](https://github.com/WebXR-JP/xrift-world-template) と揃え、派生 item で設定漏れが起きないようにする
- `@xrift/world-components` / `@react-three/uikit` を shared に追加
- `three/addons` 全体ではなく `three/addons/loaders/DRACOLoader.js` のみに限定 (world-template と同じ)
- `@xrift/world-components` を `dependencies` に追加 (`^0.36.1` — world-template と同バージョン)

## 変更点
### vite.config.ts
- `three/addons` → `three/addons/loaders/DRACOLoader.js` に変更
- `@react-three/uikit` (`^1.0.0`) を shared に追加
- `@xrift/world-components` (`^0.1.0`) を shared に追加

### package.json
- `dependencies` に `@xrift/world-components ^0.36.1` を追加
- `devDependencies` に `@react-three/uikit ^1.0.64` を追加

## Test plan
- [x] `npm run build` が成功する
- [x] `xrift check` が APPROVE で通る (28 ファイル)
- [ ] world-template と federation shared の構成が一致していることをレビューで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)