### PR TITLE
refactor: Item から position/scale props を削除

### DIFF
--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -3,12 +3,7 @@ import { useFrame } from '@react-three/fiber'
 import { RigidBody } from '@react-three/rapier'
 import { Mesh, Group } from 'three'
 
-export interface ItemProps {
-  position?: [number, number, number]
-  scale?: number
-}
-
-export const Item: React.FC<ItemProps> = ({ position = [0, 0, 0], scale = 1 }) => {
+export const Item = () => {
   const groupRef = useRef<Group>(null)
   const crystalRef = useRef<Mesh>(null)
 
@@ -20,7 +15,7 @@ export const Item: React.FC<ItemProps> = ({ position = [0, 0, 0], scale = 1 }) =
   })
 
   return (
-    <group ref={groupRef} position={position} scale={scale}>
+    <group ref={groupRef}>
       {/* 台座 */}
       <RigidBody type="fixed" colliders="cuboid">
         <mesh position={[0, 0.15, 0]} castShadow receiveShadow>

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -26,7 +26,7 @@ createRoot(rootElement).render(
             intensity={1}
             castShadow
           />
-          <Item position={[0, 0, 0]} />
+          <Item />
           {/* 地面 */}
           <mesh receiveShadow rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]}>
             <planeGeometry args={[10, 10]} />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,1 @@
 export { Item } from './Item'
-export type { ItemProps } from './Item'


### PR DESCRIPTION
## Summary
- `Item` コンポーネントから `position` / `scale` props を削除（配置・スケールはホスト側ワールドで制御するため二重管理を回避）
- `React.FC<ItemProps>` をやめて素の関数宣言に変更し、不要になった `ItemProps` 型と re-export も削除
- `dev.tsx` の `<Item />` 呼び出しもデフォルトに合わせて更新

## Test plan
- [ ] `npm run dev` で開発サーバーが起動し、Item が以前と同じ位置・大きさで表示される
- [ ] `npm run build` が成功する
- [ ] ホスト（xrift-frontend）に読み込んだ際にアイテムが正しく配置される

🤖 Generated with [Claude Code](https://claude.com/claude-code)