### PR TITLE
chore: @xrift/world-components を 0.41.0 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@xrift/item-template",
       "version": "0.1.0",
       "dependencies": {
-        "@xrift/world-components": "^0.36.1"
+        "@xrift/world-components": "^0.41.0"
       },
       "devDependencies": {
         "@originjs/vite-plugin-federation": "^1.4.1",
@@ -1970,9 +1970,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xrift/world-components": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.36.1.tgz",
-      "integrity": "sha512-mSXA3Ibe0eZcPMbl8JZ7VB18syYf6AqnYn25N+nylqoPFuddPp/ZIO/bxm8TOltBSWmCC2exmUNMWgY40vpm8w==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.41.0.tgz",
+      "integrity": "sha512-fZL622Zogh3lepgo3lFwsDr1vZWDDWkxdqqEbpzb0x91hgf+jxTCZkBuu1fepYmCosARp7VMeEnRrzex17FOug==",
       "license": "MIT",
       "peerDependencies": {
         "@react-three/drei": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@xrift/world-components": "^0.36.1"
+    "@xrift/world-components": "^0.41.0"
   }
 }


### PR DESCRIPTION
## Summary
- `@xrift/world-components` を `^0.36.1` → `^0.41.0` に更新
- `npm run build` 通過確認済み

## Test plan
- [ ] `npm run dev` で開発サーバーが起動し、Item が正しく表示される
- [ ] `npm run build` が成功する
- [ ] ホスト（xrift-frontend）に読み込んだ際に挙動が変わっていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)